### PR TITLE
Use markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ for available targets.
 ## Configuration
 
 The plugin is configured using environment variables:
-```
+
 ENV VAR                          | Default  |  Description                               | Example               
  ------------------------------- |  ------- |  ----------------------------------------- |  ---------------------
 FLYTE_API                        | -        | The API endpoint to use                    | http://localhost:8080
 FLYTE_API_TIMEOUT                | 10 secs  | Combined timeout for accessing the API     | 20
 FLYTE_LABELS                     | -        | Labels to disambiguate this instance       | env=staging,bar=foo
-```
+
 
 ## Example Flow
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ The plugin is configured using environment variables:
 
 ENV VAR                          | Default  |  Description                               | Example               
  ------------------------------- |  ------- |  ----------------------------------------- |  ---------------------
-FLYTE_API                        | -        | The API endpoint to use                    | http://localhost:8080
-FLYTE_API_TIMEOUT                | 10 secs  | Combined timeout for accessing the API     | 20
-FLYTE_LABELS                     | -        | Labels to disambiguate this instance       | env=staging,bar=foo
+`FLYTE_API`                      | -        | The API endpoint to use                    | http://localhost:8080
+`FLYTE_API_TIMEOUT`              | 10 secs  | Combined timeout for accessing the API     | 20
+`FLYTE_LABELS`                   | -        | Labels to disambiguate this instance       | env=staging,bar=foo
 
 
 ## Example Flow


### PR DESCRIPTION
Maybe it's just personal preference but I think a markdown table looks better and easier to read:

Have a look 🙂https://github.com/csabapalfi/flyte-ticker/blob/b72a3775170e2884bf72738f5db60d0332555516/README.md#configuration